### PR TITLE
Handle shapefiles missing SHX and safe preview

### DIFF
--- a/polygon_split.py
+++ b/polygon_split.py
@@ -25,6 +25,9 @@ import logging
 # Import type hints for better code documentation
 from typing import List, Union, Tuple, Optional
 
+# Automatically recreate missing .shx files when reading shapefiles
+os.environ.setdefault("SHAPE_RESTORE_SHX", "YES")
+
 # Set up basic logging configuration
 logging.basicConfig(level=logging.INFO)
 # Create a logger instance for this module
@@ -407,8 +410,12 @@ def main():
                         st.error(f"Failed to read shapefile: {str(e)}")
                         raise
 
+                # Convert geometry to WKT strings for a safe preview in Streamlit
+                gdf_preview = gdf.copy()
+                gdf_preview["geometry"] = gdf_preview.geometry.to_wkt()
+
                 st.write("Original Shapefile Preview:")
-                st.write(gdf)
+                st.dataframe(gdf_preview)
                 
                 fig = gdf.plot(figsize=(10, 10))
                 st.pyplot(fig.figure)


### PR DESCRIPTION
## Summary
- Ensure GDAL restores or creates missing `.shx` files before reading shapefiles
- Preview GeoDataFrames in Streamlit with geometry converted to WKT strings to avoid Arrow errors

## Testing
- `python -m py_compile polygon_split.py`
- `python - <<'PY'
import polygon_split
import geopandas as gpd
from shapely.geometry import Polygon
import os, tempfile
poly=Polygon([(0,0),(1,0),(1,1),(0,1)])
with tempfile.TemporaryDirectory() as td:
    path=os.path.join(td,'square.shp')
    gdf=gpd.GeoDataFrame({'id':[1]},geometry=[poly],crs='EPSG:4326')
    gdf.to_file(path)
    os.remove(os.path.join(td,'square.shx'))
    try:
        gdf2=gpd.read_file(path)
        print('read success', gdf2)
    except Exception as e:
        print('error',e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c7f0594e28832facf5d3844825e5f3