### PR TITLE
Handle missing geometries when previewing WKT

### DIFF
--- a/polygon_split.py
+++ b/polygon_split.py
@@ -428,7 +428,10 @@ def main():
 
                 # Convert geometry to WKT strings for a safe preview in Streamlit
                 gdf_preview = gdf.copy()
-                gdf_preview["geometry_wkt"] = gdf_preview.geometry.apply(lambda geom: geom.wkt)
+                # Safely convert geometries to WKT; handle missing geometries
+                gdf_preview["geometry_wkt"] = gdf_preview.geometry.apply(
+                    lambda geom: geom.wkt if geom is not None else None
+                )
 
 
                 st.write("Original Shapefile Preview:")


### PR DESCRIPTION
## Summary
- avoid crashes when shapefile has missing geometries by checking for `None` before converting to WKT

## Testing
- `python -m py_compile polygon_split.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7fd6ea160832f9dc4f8e15e120e41